### PR TITLE
add overlap_side and fix attention mask

### DIFF
--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -104,6 +104,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("mllama", "MllamaProcessor"),
         ("mm-grounding-dino", "GroundingDinoProcessor"),
         ("moonshine", "Wav2Vec2Processor"),
+        ("moss_ttsd", "MossTTSDProcessor"),
         ("oneformer", "OneFormerProcessor"),
         ("ovis2", "Ovis2Processor"),
         ("owlv2", "Owlv2Processor"),

--- a/src/transformers/models/xy_tokenizer/__init__.py
+++ b/src/transformers/models/xy_tokenizer/__init__.py
@@ -19,6 +19,7 @@ from ...utils.import_utils import define_import_structure
 
 if TYPE_CHECKING:
     from .configuration_xy_tokenizer import *
+    from .feature_extraction_xy_tokenizer import *
     from .modeling_xy_tokenizer import *
 else:
     import sys

--- a/src/transformers/models/xy_tokenizer/configuration_xy_tokenizer.py
+++ b/src/transformers/models/xy_tokenizer/configuration_xy_tokenizer.py
@@ -29,45 +29,45 @@ class XYTokenizerConfig(PretrainedConfig):
     documentation from [`PretrainedConfig`] for more information.
 
     Args:
-            input_sample_rate (`int`, *optional*, defaults to 16000):
-                The sampling rate of the input audio.
-            output_sample_rate (`int`, *optional*, defaults to 16000):
-                The sampling rate of the output audio.
-            encoder_downsample_rate (`int`, *optional*, defaults to 1280):
-                The total downsampling factor of the encoder part.
-            decoder_upsample_rate (`int`, *optional*, defaults to 1920):
-                The total upsampling factor of the decoder part.
-            code_dim (`int`, *optional*, defaults to 1280):
-                The dimension of the code embeddings.
-            semantic_encoder_d_model (`int`, *optional*, defaults to 1280):
-                Hidden dimension for the semantic encoder.
-            acoustic_encoder_d_model (`int`, *optional*, defaults to 1280):
-                Hidden dimension for the acoustic encoder.
-            num_quantizers (`int`, *optional*, defaults to 32):
-                Number of residual quantizers.
-            codebook_size (`int`, *optional*, defaults to 1024):
-                Size of each codebook.
-            codebook_dim (`int`, *optional*, defaults to 8):
-                Dimension of each codebook entry.
-            hidden_size (`int`, *optional*, defaults to 1280):
-                Hidden size for transformer layers.
-            num_attention_heads (`int`, *optional*, defaults to 20):
-                Number of attention heads in transformer layers.
-            intermediate_size (`int`, *optional*, defaults to 5120):
-                Intermediate size in feed-forward networks.
-            num_hidden_layers (`int`, *optional*, defaults to 32):
-                Number of hidden layers in transformers.
-            activation_function (`str`, *optional*, defaults to `"gelu"`):
-                The activation function to use.
-            dropout (`float`, *optional*, defaults to 0.0):
-                The dropout probability.
-            attention_dropout (`float`, *optional*, defaults to 0.0):
-                The dropout probability for attention layers.
-            max_position_embeddings (`int`, *optional*, defaults to 1500):
-                Maximum position embeddings.
-            initializer_range (`float`, *optional*, defaults to 0.02):
-                The standard deviation for weight initialization.
-            use_cache (`bool`, *optional*, defaults to `True`): <fill_docstring>
+        input_sample_rate (`int`, *optional*, defaults to 16000):
+            The sampling rate of the input audio.
+        output_sample_rate (`int`, *optional*, defaults to 16000):
+            The sampling rate of the output audio.
+        encoder_downsample_rate (`int`, *optional*, defaults to 1280):
+            The total downsampling factor of the encoder part.
+        decoder_upsample_rate (`int`, *optional*, defaults to 1920):
+            The total upsampling factor of the decoder part.
+        code_dim (`int`, *optional*, defaults to 1280):
+            The dimension of the code embeddings.
+        semantic_encoder_d_model (`int`, *optional*, defaults to 1280):
+            Hidden dimension for the semantic encoder.
+        acoustic_encoder_d_model (`int`, *optional*, defaults to 1280):
+            Hidden dimension for the acoustic encoder.
+        num_quantizers (`int`, *optional*, defaults to 32):
+            Number of residual quantizers.
+        codebook_size (`int`, *optional*, defaults to 1024):
+            Size of each codebook.
+        codebook_dim (`int`, *optional*, defaults to 8):
+            Dimension of each codebook entry.
+        hidden_size (`int`, *optional*, defaults to 1280):
+            Hidden size for transformer layers.
+        num_attention_heads (`int`, *optional*, defaults to 20):
+            Number of attention heads in transformer layers.
+        intermediate_size (`int`, *optional*, defaults to 5120):
+            Intermediate size in feed-forward networks.
+        num_hidden_layers (`int`, *optional*, defaults to 32):
+            Number of hidden layers in transformers.
+        activation_function (`str`, *optional*, defaults to `"gelu"`):
+            The activation function to use.
+        dropout (`float`, *optional*, defaults to 0.0):
+            The dropout probability.
+        attention_dropout (`float`, *optional*, defaults to 0.0):
+            The dropout probability for attention layers.
+        max_position_embeddings (`int`, *optional*, defaults to 1500):
+            Maximum position embeddings.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation for weight initialization.
+        use_cache (`bool`, *optional*, defaults to `True`): <fill_docstring>
     """
     model_type = "xy_tokenizer"
 

--- a/src/transformers/models/xy_tokenizer/feature_extraction_xy_tokenizer.py
+++ b/src/transformers/models/xy_tokenizer/feature_extraction_xy_tokenizer.py
@@ -18,6 +18,7 @@ Feature extractor class for XY-Tokenizer
 import math
 from functools import partial
 from typing import List, Optional, Union
+from collections import deque
 
 import torch
 import torch.nn.functional as F
@@ -37,6 +38,7 @@ class ExtractorIterator:
         batch_size=1,
         chunk_length=30,
         overlap_seconds=10,
+        overlap_side="both",
         sampling_rate=16000,
         encode_func=None,
     ) -> None:
@@ -44,12 +46,16 @@ class ExtractorIterator:
         self.batch_size = batch_size
         self.chunk_length = chunk_length
         self.overlap_seconds = overlap_seconds
+        self.overlap_side = overlap_side
         self.sampling_rate = sampling_rate
 
         # duration_size is the effective audio length of each processing
         self.chunk_size = int(self.chunk_length * self.sampling_rate)
-        self.duration_seconds = self.chunk_length - self.overlap_seconds
-        self.duration_size = int(self.duration_seconds * self.sampling_rate)
+        self.overlap_size = int(self.overlap_seconds * self.sampling_rate)
+        self.duration_size = self.chunk_size - self.overlap_size
+        assert (
+            (overlap_side == "right") or (self.overlap_size % 2 == 0)
+        ), '`overlap_seconds` must be divisible by 2 when `overlap_side` is "both".'
         # Note: here we only process non-overlapping blocks, and overlap will be processed outside (if needed)
         # or more explicitly in the iterator. For simplicity, we assume that the blocks are based on duration_size
 
@@ -65,33 +71,13 @@ class ExtractorIterator:
 
         # NOTE: The chunk size output by chunk_and_pad_view is duration_size
         wav_tensor = torch.zeros(self.batch_size, 1, self.chunk_size)
-        input_lengths = torch.zeros(self.batch_size, dtype=torch.long)
+        input_lengths = deque(maxlen=self.batch_size)
         input_seq_no = torch.zeros(self.batch_size, dtype=torch.long)
-
-        def chunk_and_pad_view(tensor, seq_no):
-            x = tensor[0:1, :].unsqueeze(0)
-
-            stride = self.duration_size
-            kernel = self.chunk_size
-            B, C, L = x.shape
-
-            num_chunks = math.ceil(L / stride)
-            target_len = (num_chunks - 1) * stride + kernel
-            padding_size = max(0, target_len - L)
-            x_padded = F.pad(x, (0, padding_size), "constant", 0)
-            output_tensor = (
-                x_padded.unfold(dimension=2, size=kernel, step=stride)
-                .squeeze(0)
-                .transpose(0, 1)
-            )
-            output_lengths = torch.full((num_chunks,), kernel, dtype=torch.long)
-            for i in range(num_chunks):
-                output_lengths[i] = min(output_lengths[i], L - stride * i)
-            output_seq_no = torch.full((num_chunks,), seq_no, dtype=torch.long)
-            return output_tensor, output_lengths, output_seq_no
+        
+        right_boundary = self.get_right_boundary()
 
         for i, sample in enumerate(self.data):
-            sample_chunks, sample_lengths, sample_seq_no = chunk_and_pad_view(sample, i)
+            sample_chunks, sample_lengths, sample_seq_no = self.chunk_and_pad_view(sample, i)
 
             processed_in_sample = 0
             while processed_in_sample < len(sample_chunks):
@@ -110,9 +96,7 @@ class ExtractorIterator:
                 wav_tensor[start_idx_batch:end_idx_batch] = sample_chunks[
                     start_idx_sample:end_idx_sample
                 ]
-                input_lengths[start_idx_batch:end_idx_batch] = sample_lengths[
-                    start_idx_sample:end_idx_sample
-                ]
+                input_lengths.extend(sample_lengths[start_idx_sample:end_idx_sample])
                 input_seq_no[start_idx_batch:end_idx_batch] = sample_seq_no[
                     start_idx_sample:end_idx_sample
                 ]
@@ -123,10 +107,16 @@ class ExtractorIterator:
 
                 # If the batch is full, yield a copy and reset
                 if batch_num == self.batch_size:
-                    list_x = [
-                        wav_tensor[xi, :, :x_len].reshape(-1).cpu().numpy()
-                        for xi, x_len in enumerate(input_lengths.tolist())
-                    ]
+                    list_x = []
+                    for xi, (_, right) in enumerate(input_lengths):
+                        if right == right_boundary and torch.any(
+                            wav_tensor[xi, :, right:] != 0
+                        ):
+                            list_x.append(wav_tensor[xi].reshape(-1).cpu().numpy())
+                        else:
+                            list_x.append(
+                                wav_tensor[xi, :, :right].reshape(-1).cpu().numpy()
+                            )
                     yield BatchFeature(
                         {
                             **self.encode_func(list_x),
@@ -138,15 +128,22 @@ class ExtractorIterator:
                     # Reset batch counter and Tensor content
                     batch_num = 0
                     wav_tensor.zero_()
-                    input_lengths.zero_()
+                    input_lengths.clear()
                     input_seq_no.zero_()
 
         # After the loop, process the last incomplete batch
         if batch_num > 0:
-            list_x = [
-                wav_tensor[xi, :, :x_len].reshape(-1).cpu().numpy()
-                for xi, x_len in enumerate(input_lengths.tolist())
-            ]
+            list_x = []
+            for xi in range(batch_num):
+                _, right = input_lengths[xi]
+                if right == right_boundary and torch.any(
+                    wav_tensor[xi, :, right:] != 0
+                ):
+                    list_x.append(wav_tensor[xi].reshape(-1).cpu().numpy())
+                else:
+                    list_x.append(
+                        wav_tensor[xi, :, :right].reshape(-1).cpu().numpy()
+                    )
             yield BatchFeature(
                 {
                     **self.encode_func(list_x),
@@ -154,6 +151,50 @@ class ExtractorIterator:
                     "chunk_seq_no": input_seq_no[:batch_num].clone(),
                 }
             )
+
+    def chunk_and_pad_view(self, tensor, seq_no):
+        x = tensor[0:1, :].unsqueeze(0)
+        
+        stride = self.duration_size
+        kernel = self.chunk_size
+        B, C, L = x.shape
+    
+        num_chunks = max(0, math.ceil((L - kernel) / stride)) + 1
+        target_len = (num_chunks - 1) * stride + kernel
+        padding_size = max(0, target_len - L)
+        x_padded = F.pad(x, (0, padding_size), "constant", 0)
+        output_tensor = (
+            x_padded.unfold(dimension=2, size=kernel, step=stride)
+            .squeeze(0)
+            .transpose(0, 1)
+        )
+        
+        output_lengths = self.get_windows_boundaries(num_chunks, L)
+        output_seq_no = torch.full((num_chunks,), seq_no, dtype=torch.long)
+        return output_tensor, output_lengths, output_seq_no
+
+    def get_left_boundary(self):
+        if self.overlap_side == "right":
+            return 0
+        else:
+            return int(self.overlap_size / 2)
+
+    def get_right_boundary(self):
+        if self.overlap_side == "right":
+            return self.duration_size
+        else:
+            return self.chunk_size - int(self.overlap_size / 2)
+            
+    def get_windows_boundaries(self, num_chunks, seq_len):
+        left_boundary = self.get_left_boundary()
+        right_boundary = self.get_right_boundary()
+
+        output_lengths = [(left_boundary, right_boundary) for _ in range(num_chunks)]
+        output_lengths[0] = (0, output_lengths[0][1])
+        output_lengths[-1] = (
+            output_lengths[-1][0], seq_len - self.duration_size * (num_chunks-1)
+        )
+        return output_lengths
 
 
 class XYTokenizerFeatureExtractor(WhisperFeatureExtractor):
@@ -171,7 +212,8 @@ class XYTokenizerFeatureExtractor(WhisperFeatureExtractor):
         dither=0.0,
         return_attention_mask=False,
         max_frequency=None,
-        batch_size=None,
+        batch_size=8,
+        overlap_side="both", 
         **kwargs,
     ):
         super().__init__(
@@ -201,6 +243,7 @@ class XYTokenizerFeatureExtractor(WhisperFeatureExtractor):
             norm="slaney",
             mel_scale="slaney",
         )
+        self.overlap_side = overlap_side
 
     def __call__(
         self,
@@ -224,9 +267,10 @@ class XYTokenizerFeatureExtractor(WhisperFeatureExtractor):
 
         return ExtractorIterator(
             raw_speech,
-            batch_size=len(raw_speech) if self.batch_size is None else self.batch_size,
+            batch_size=self.batch_size if self.batch_size else len(raw_speech), 
             chunk_length=self.chunk_length,
             overlap_seconds=overlap_seconds,
+            overlap_side=self.overlap_side,
             sampling_rate=self.sampling_rate,
             encode_func=partial(
                 super().__call__,
@@ -245,4 +289,4 @@ class XYTokenizerFeatureExtractor(WhisperFeatureExtractor):
         )
 
 
-__all__ = ["XYTokenizerFeatureExtractor", "ExtractorIterator"]
+__all__ = ["XYTokenizerFeatureExtractor"]

--- a/src/transformers/models/xy_tokenizer/modeling_xy_tokenizer.py
+++ b/src/transformers/models/xy_tokenizer/modeling_xy_tokenizer.py
@@ -28,7 +28,6 @@ from einops import rearrange
 from torch.nn.utils.parametrizations import weight_norm
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache
 from ...feature_extraction_utils import BatchFeature
 from ...modeling_attn_mask_utils import _prepare_4d_attention_mask
 from ...modeling_outputs import ModelOutput
@@ -175,14 +174,12 @@ class XYTokenizerAttention(nn.Module):
         num_heads: int,
         dropout: float = 0.0,
         is_causal: bool = False,
-        config: Optional[XYTokenizerConfig] = None,
     ):
         super().__init__()
         self.embed_dim = embed_dim
         self.num_heads = num_heads
         self.dropout = dropout
         self.head_dim = embed_dim // num_heads
-        self.config = config
 
         if (self.head_dim * num_heads) != self.embed_dim:
             raise ValueError(
@@ -199,6 +196,19 @@ class XYTokenizerAttention(nn.Module):
 
     def _shape(self, tensor: torch.Tensor, seq_len: int, bsz: int):
         return tensor.view(bsz, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
+
+    def _create_attention_mask(self, seq_len, max_len, device, dtype):
+        bsz = seq_len.size(0)
+        mask = torch.ones(bsz, 1, max_len, max_len, device=device, dtype=dtype)
+        seq_indices = torch.arange(max_len, device=device).unsqueeze(0)
+        seq_len_expanded = seq_len.unsqueeze(1)
+        valid_mask = seq_indices < seq_len_expanded.unsqueeze(-1)
+        mask = mask * (valid_mask.unsqueeze(2) & valid_mask.unsqueeze(3)).to(dtype)
+        if self.is_causal:
+            causal_mask = torch.triu(torch.ones(max_len, max_len, device=device, dtype=torch.bool), diagonal=1)
+            mask = mask * (~causal_mask.unsqueeze(0).unsqueeze(1)).to(dtype)
+        mask = mask + (1.0 - mask) * torch.finfo(dtype).min
+        return mask
 
     def forward(
         self,
@@ -234,35 +244,10 @@ class XYTokenizerAttention(nn.Module):
         
         # Create attention mask based on sequence lengths if provided
         if seq_len is not None:
-            # Create a mask for valid tokens
-            max_len = tgt_len
-            seq_indices = torch.arange(max_len, device=hidden_states.device).unsqueeze(0)
-            valid_mask = seq_indices < seq_len.unsqueeze(-1)
-            
-            # Convert to attention mask format (batch_size, seq_len)
-            attention_mask = valid_mask.float()
-            
             # Apply causal mask if needed
-            if self.is_causal:
-                causal_mask = torch.triu(
-                    torch.ones(max_len, max_len, device=hidden_states.device, dtype=torch.bool),
-                    diagonal=1,
-                )
-                # Create causal attention mask
-                causal_attention_mask = (~causal_mask).float().unsqueeze(0).expand(bsz, -1, -1)
-                # Combine with length-based mask
-                attention_mask = attention_mask.unsqueeze(1) * causal_attention_mask
-                attention_mask = attention_mask.masked_fill(attention_mask == 0, float('-inf'))
-                attention_mask = attention_mask.masked_fill(attention_mask == 1, 0.0)
-                # Reshape for multi-head attention
-                attention_mask = attention_mask.unsqueeze(1).expand(-1, self.num_heads, -1, -1)
-                attention_mask = attention_mask.reshape(bsz * self.num_heads, tgt_len, src_len)
-                attn_weights = attn_weights + attention_mask
-            else:
-                # For non-causal attention, apply length-based masking after softmax
-                length_mask = valid_mask.unsqueeze(1).expand(-1, tgt_len, -1)
-                length_mask = length_mask.unsqueeze(1).expand(-1, self.num_heads, -1, -1)
-                length_mask = length_mask.reshape(bsz * self.num_heads, tgt_len, src_len)
+            attn_mask = self._create_attention_mask(seq_len, tgt_len, hidden_states.device, attn_weights.dtype)
+            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len) + attn_mask
+            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
         elif attention_mask is not None:
             # Handle externally provided attention mask
             if attention_mask.dim() == 2:
@@ -310,13 +295,12 @@ class XYTokenizerAttention(nn.Module):
 class XYTokenizerMLP(nn.Module):
     """MLP as used in XY-Tokenizer."""
 
-    def __init__(self, config: XYTokenizerConfig):
+    def __init__(self, hidden_size, intermediate_size, dropout, activation_function):
         super().__init__()
-        self.config = config
-        self.activation_fn = ACT2FN[config.activation_function]
-        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
-        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
-        self.dropout = nn.Dropout(config.dropout)
+        self.activation_fn = ACT2FN[activation_function]
+        self.fc1 = nn.Linear(hidden_size, intermediate_size)
+        self.fc2 = nn.Linear(intermediate_size, hidden_size)
+        self.dropout = nn.Dropout(dropout)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = self.fc1(hidden_states)
@@ -329,21 +313,29 @@ class XYTokenizerMLP(nn.Module):
 class XYTokenizerTransformerLayer(nn.Module):
     """Transformer layer for XY-Tokenizer."""
 
-    def __init__(self, config: XYTokenizerConfig, is_causal: bool = False):
+    def __init__(
+        self,
+        hidden_size,
+        num_attention_heads,
+        intermediate_size,
+        activation_function,
+        dropout: float = 0.0,
+        attention_dropout: float = 0.0,
+        is_causal: bool = False,
+    ):
         super().__init__()
-        self.embed_dim = config.hidden_size
+        self.embed_dim = hidden_size
         self.self_attn = XYTokenizerAttention(
             embed_dim=self.embed_dim,
-            num_heads=config.num_attention_heads,
-            dropout=config.attention_dropout,
+            num_heads=num_attention_heads,
+            dropout=attention_dropout,
             is_causal=is_causal,
-            config=config,
         )
 
-        self.mlp = XYTokenizerMLP(config)
+        self.mlp = XYTokenizerMLP(hidden_size, intermediate_size, dropout, activation_function)
         self.self_attn_layer_norm = nn.LayerNorm(self.embed_dim)
         self.final_layer_norm = nn.LayerNorm(self.embed_dim)
-        self.dropout = nn.Dropout(config.dropout)
+        self.dropout = nn.Dropout(dropout)
 
     def forward(
         self,
@@ -433,7 +425,7 @@ class OmniAudioEncoder(nn.Module):
             "positional_embedding", sinusoids(self.max_source_positions, d_model)
         )
         # Create a config object for the transformer layers
-        layer_config = XYTokenizerConfig(
+        layer_config = dict(
             hidden_size=d_model,
             num_attention_heads=encoder_attention_heads,
             intermediate_size=encoder_ffn_dim,
@@ -441,7 +433,7 @@ class OmniAudioEncoder(nn.Module):
         )
         self.layers = nn.ModuleList(
             [
-                XYTokenizerTransformerLayer(layer_config, is_causal=False)
+                XYTokenizerTransformerLayer(**layer_config, is_causal=False)
                 for _ in range(encoder_layers)
             ]
         )
@@ -520,7 +512,7 @@ class OmniAudioDecoder(nn.Module):
             "positional_embedding", sinusoids(self.max_source_positions, d_model)
         )
         # Create a config object for the transformer layers
-        layer_config = XYTokenizerConfig(
+        layer_config = dict(
             hidden_size=d_model,
             num_attention_heads=decoder_attention_heads,
             intermediate_size=decoder_ffn_dim,
@@ -528,7 +520,7 @@ class OmniAudioDecoder(nn.Module):
         )
         self.layers = nn.ModuleList(
             [
-                XYTokenizerTransformerLayer(layer_config, is_causal=False)
+                XYTokenizerTransformerLayer(**layer_config, is_causal=False)
                 for _ in range(decoder_layers)
             ]
         )
@@ -638,7 +630,7 @@ class XYTokenizerTransformer(nn.Module):
             "positional_embedding", sinusoids(self.max_source_positions, d_model)
         )
         # Create a config object for the transformer layers
-        layer_config = XYTokenizerConfig(
+        layer_config = dict(
             hidden_size=d_model,
             num_attention_heads=encoder_attention_heads,
             intermediate_size=encoder_ffn_dim,
@@ -646,7 +638,7 @@ class XYTokenizerTransformer(nn.Module):
         )
         self.layers = nn.ModuleList(
             [
-                XYTokenizerTransformerLayer(layer_config, is_causal=False)
+                XYTokenizerTransformerLayer(**layer_config, is_causal=False)
                 for _ in range(encoder_layers)
             ]
         )
@@ -1406,6 +1398,16 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
             [_get_out_len(l) for l in input_lengths], device=self.device
         )
 
+    def scale_window_size(self, boundaries, scaling_factor):
+        scaling_range = []
+        scaling_boundaries = []
+        for left_boundary, right_boundary in boundaries:
+            scaling_left_boundary = left_boundary// scaling_factor
+            scaling_right_boundary = right_boundary // scaling_factor
+            scaling_range.append(scaling_right_boundary-scaling_left_boundary)
+            scaling_boundaries.append(slice(scaling_left_boundary, scaling_right_boundary))
+        return scaling_range, scaling_boundaries
+
     @add_start_docstrings_to_model_forward(XY_TOKENIZER_INPUTS_DOCSTRING)
     @torch.no_grad()
     def encode(
@@ -1447,16 +1449,13 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
                 chunk_output = self._encode(
                     chunk_features, n_quantizers, return_dict=True
                 )
-                valid_code_lengths = (
-                    torch.clamp(
-                        chunk_features["input_lengths"], 0, features.duration_size
-                    )
-                    // self.encoder_downsample_rate
+                valid_code_lengths, valid_code_ranges = self.scale_window_size(
+                    chunk_features["input_lengths"], self.encoder_downsample_rate
                 )
 
                 # Accumulate weighted commit loss
                 chunk_length = chunk_output.codes_lengths.sum().item()
-                valid_chunk_length = valid_code_lengths.sum().item()
+                valid_chunk_length = sum(valid_code_lengths)
                 if chunk_output.commit_loss is not None and valid_chunk_length > 0:
                     commit_loss = (
                         chunk_output.commit_loss / chunk_length * valid_chunk_length
@@ -1466,18 +1465,18 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
 
                 # Group results by original sequence ID
                 for i, seq_id in enumerate(chunk_features["chunk_seq_no"].tolist()):
-                    valid_code_length = valid_code_lengths[i]
-                    if valid_code_length > 0:
+                    valid_code_range = valid_code_ranges[i]
+                    if valid_code_range.stop > 0:
                         encodings[seq_id]["zq"].append(
                             chunk_output.quantized_representation[
-                                i : i + 1, :, :valid_code_length
+                                i : i + 1, :, valid_code_range
                             ]
                         )
                         encodings[seq_id]["codes"].append(
-                            chunk_output.audio_codes[:, i : i + 1, :valid_code_length]
+                            chunk_output.audio_codes[:, i : i + 1, valid_code_range]
                         )
                         # Add the valid length of this chunk to the total for this sequence
-                        encodings[seq_id]["length"] += valid_code_lengths[i].item()
+                        encodings[seq_id]["length"] += valid_code_lengths[i]
 
             final_outputs = []
             for seq_id, seq_data in encodings.items():
@@ -1571,6 +1570,7 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
             pre_rvq_adapter_output, pre_rvq_adapter_output_length
         )
 
+        torch.save(downsample_output, "outputs/hidden1.pt")
         n_quantizers = n_quantizers or self.quantizer.num_quantizers
         zq, codes, vq_loss, _, quantizer_output_length = self.quantizer(
             downsample_output, downsample_output_length, n_quantizers=n_quantizers
@@ -1785,7 +1785,7 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
         >>> import torch
 
         >>> # This is a placeholder model name, replace with the actual one on the Hub
-        >>> model_id = "your-namespace/xy-codec-model"
+        >>> model_id = "your-namespace/xy-tokenizer-model"
         >>> model = AutoModel.from_pretrained(model_id)
         >>> # The feature extractor config is part of the model config, so it can be loaded this way
         >>> feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)
@@ -1855,4 +1855,7 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
         )
 
 
-__all__ = ["XYTokenizerModel"]
+__all__ = [
+    "XYTokenizerModel",
+    "XYTokenizerPreTrainedModel",
+]

--- a/src/transformers/models/xy_tokenizer/modeling_xy_tokenizer.py
+++ b/src/transformers/models/xy_tokenizer/modeling_xy_tokenizer.py
@@ -1402,7 +1402,7 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
         scaling_range = []
         scaling_boundaries = []
         for left_boundary, right_boundary in boundaries:
-            scaling_left_boundary = left_boundary// scaling_factor
+            scaling_left_boundary = left_boundary // scaling_factor
             scaling_right_boundary = right_boundary // scaling_factor
             scaling_range.append(scaling_right_boundary-scaling_left_boundary)
             scaling_boundaries.append(slice(scaling_left_boundary, scaling_right_boundary))
@@ -1570,7 +1570,6 @@ class XYTokenizerModel(XYTokenizerPreTrainedModel):
             pre_rvq_adapter_output, pre_rvq_adapter_output_length
         )
 
-        torch.save(downsample_output, "outputs/hidden1.pt")
         n_quantizers = n_quantizers or self.quantizer.num_quantizers
         zq, codes, vq_loss, _, quantizer_output_length = self.quantizer(
             downsample_output, downsample_output_length, n_quantizers=n_quantizers


### PR DESCRIPTION
## update:

- Add `overlap_side` parameter, which defaults to "both", to enable overlapping on both the left and right sides of the sliding window.
- Fix an implementation issue with `attn_mask` in *modeling_xy_tokenizer.py*
- Add **MossTTSDProcessor** to *processing_auto.py*